### PR TITLE
fix(build): Keystore pointed to the local dir

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,10 +14,10 @@ android {
     
     signingConfigs {
         debugConf {
-            keyAlias "androiddebugkey"
-            keyPassword "UBAH_PASSWORD_INI"
-            storeFile file("C:\Users\bagong\.android\debug.keystore")
-            storePassword "UBAH_PASSWORD_INI"
+            keyAlias 'androiddebugkey'
+            keyPassword 'UBAH_PASSWORD_INI'
+            storeFile file('debug.keystore')
+            storePassword 'UBAH_PASSWORD_INI'
         }
     }
     


### PR DESCRIPTION
Prevent using user default directory and point to the current/root project directory instead

@helsanf 